### PR TITLE
Added functions to keymap section in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ detachstack(Client *c)
 - `<leader>cf` - Single line comment
 - `<leader>cm` - Multiline comment
 
+Functions to map to any key. :smile:
+```vim
+:lua require('nvim-comment-frame').add_comment()<CR>
+
+:lua require('nvim-comment-frame').add_multiline_comment()<CR>
+```
+
 ## Install
 
 **Packer**


### PR DESCRIPTION
I was looking for these functions to map my custom labeled key maps using which-key, so I thought it can be useful to have them in the README so other people doesn't have to look in the code. 😊