### PR TITLE
feat: remove hard dependency on `nvim-treesitter`

### DIFF
--- a/lua/nvim-comment-frame/util.lua
+++ b/lua/nvim-comment-frame/util.lua
@@ -1,5 +1,3 @@
-local parsers = require('nvim-treesitter.parsers')
-
 ---@diagnostic disable-next-line: undefined-global
 local v = vim
 local api = v.api
@@ -197,7 +195,7 @@ local Treesitter = {}
 
 -- Returns the language for current line using treesitter
 function Treesitter.get_curr_lang()
-    local parser = parsers.get_parser(api.nvim_get_current_buf())
+    local parser = vim.treesitter.get_parser(api.nvim_get_current_buf())
     local line = Nvim.get_curr_cursor()[1]
 
     return parser:language_for_range({ line, 0, line, 0 }):lang()
@@ -205,7 +203,7 @@ end
 
 function Treesitter.get_lang_stack_for_position(cursor, buffer)
     local range = { cursor[1], cursor[2], cursor[1], cursor[2] }
-    local root_parser = parsers.get_parser(buffer)
+    local root_parser = vim.treesitter.get_parser(buffer)
 
     if not root_parser then
         return


### PR DESCRIPTION
`vim.treesitter.get_parser` does the same job, while not depending on an external module.